### PR TITLE
Fix random selection from given array of methods

### DIFF
--- a/Sources/ObfuscateMacroPlugin/Macros/ObfuscatedString.swift
+++ b/Sources/ObfuscateMacroPlugin/Macros/ObfuscatedString.swift
@@ -131,12 +131,11 @@ extension ObfuscatedString: ExpressionMacro {
             } else if candidates.count == 1 {
                 return candidates[0]
             } else {
-                let allCases = ObfuscateMethod.Element.allCases
                 let index = Int.random(
-                    in: allCases.startIndex..<allCases.endIndex,
+                    in: candidates.startIndex..<candidates.endIndex,
                     using: &randomNumberGenerator
                 )
-                return allCases[index]
+                return candidates[index]
             }
         }
 


### PR DESCRIPTION
If a random array of >=2 methods was passed to the macro, repetitions would select each method from `allCases` rather than the passed array of candidate methods.

Unfortunately, writing effective tests for this would require a deterministic PRNG (possibly from [swift-gen](https://github.com/pointfreeco/swift-gen)) and also run the risk of causing test failures in the case of future code refactoring if the order and amount of RNG calls don't remain exactly the same, which are changes that seem too big to make without the maintainer's input. Currently, `.randomAll` + repetitions isn't tested.