### PR TITLE
Update packages to get rid off compile errors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-algorithms",
       "state" : {
-        "revision" : "bcd4f369ac962bc3e5244c9df778739f8f5bdbf1",
-        "version" : "1.1.0"
+        "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
+        "version" : "1.2.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
-        "version" : "510.0.2"
+        "revision" : "cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25",
+        "version" : "600.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/swiftlang/swift-syntax.git",
-            "509.0.1"..<"511.0.0"
+            "509.0.0"..<"601.0.0-prerelease"
         ),
         .package(
             url: "https://github.com/apple/swift-algorithms",


### PR DESCRIPTION
It doesn't work with the latest [TCA](https://github.com/pointfreeco/swift-composable-architecture) due to using different versions of `swift-syntax`

<img width="1450" alt="image" src="https://github.com/user-attachments/assets/855ec6e6-c786-432e-b75f-1b47df371eef">
