### PR TITLE
Migrate `CryptoKit` to `swift-crypto`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "ffca28be3c9c6a86a579949d23f68818a4b9b5d8",
+        "version" : "3.8.0"
+      }
+    },
+    {
       "identity" : "swift-numerics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics.git",

--- a/Package.swift
+++ b/Package.swift
@@ -26,13 +26,18 @@ let package = Package(
         .package(
             url: "https://github.com/apple/swift-algorithms",
             from: "1.1.0"
-        )
+        ),
+        .package(
+            url: "https://github.com/apple/swift-crypto.git",
+            from: "3.0.0"
+        ),
     ],
     targets: [
         .target(
             name: "ObfuscateMacro",
             dependencies: [
                 .product(name: "Algorithms", package: "swift-algorithms"),
+                .product(name: "Crypto", package: "swift-crypto"),
                 "ObfuscateMacroPlugin",
                 "ObfuscateSupport"
             ]
@@ -46,6 +51,7 @@ let package = Package(
                 .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
                 .product(name: "SwiftParserDiagnostics", package: "swift-syntax"),
                 .product(name: "Algorithms", package: "swift-algorithms"),
+                .product(name: "Crypto", package: "swift-crypto"),
                 "ObfuscateSupport"
             ]
         ),

--- a/Sources/ObfuscateMacro/Exported.swift
+++ b/Sources/ObfuscateMacro/Exported.swift
@@ -1,5 +1,2 @@
 @_exported import Algorithms
-
-#if canImport(CryptoKit)
-@_exported import CryptoKit
-#endif
+@_exported import Crypto

--- a/Sources/ObfuscateMacroPlugin/Extension/Data+.swift
+++ b/Sources/ObfuscateMacroPlugin/Extension/Data+.swift
@@ -7,9 +7,7 @@
 //
 
 import Foundation
-#if canImport(CryptoKit)
-import CryptoKit
-#endif
+import Crypto
 
 extension Data {
     var array: [UInt8]? {
@@ -21,7 +19,6 @@ extension Data {
     }
 }
 
-#if canImport(CryptoKit)
 extension Data {
     /// Generates a new random symmetric key data of the given size.
     /// - Parameters:
@@ -77,4 +74,3 @@ extension Data {
         return nonceData
     }
 }
-#endif

--- a/Sources/ObfuscateMacroPlugin/Extension/ObfuscateMethod+.swift
+++ b/Sources/ObfuscateMacroPlugin/Extension/ObfuscateMethod+.swift
@@ -15,9 +15,7 @@ extension ObfuscateMethod {
         case "bitShift": self = .bitShift
         case "bitXOR": self = .bitXOR
         case "base64": self = .base64
-#if canImport(CryptoKit)
         case "AES": self = .AES
-#endif
         case "randomAll": self = .randomAll
         default: return nil
         }
@@ -30,9 +28,7 @@ extension ObfuscateMethod.Element {
         case "bitShift": self = .bitShift
         case "bitXOR": self = .bitXOR
         case "base64": self = .base64
-#if canImport(CryptoKit)
         case "AES": self = .AES
-#endif
         default: return nil
         }
     }
@@ -47,10 +43,8 @@ extension ObfuscateMethod {
             return [.bitXOR]
         case .base64:
             return [.base64]
-#if canImport(CryptoKit)
         case .AES:
             return [.AES]
-#endif
         case .randomAll:
             return Element.allCases
         case .random(let array):

--- a/Sources/ObfuscateMacroPlugin/Macros/ObfuscatedString.swift
+++ b/Sources/ObfuscateMacroPlugin/Macros/ObfuscatedString.swift
@@ -11,9 +11,7 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import Foundation
-#if canImport(CryptoKit)
-import CryptoKit
-#endif
+import Crypto
 import ObfuscateSupport
 
 struct ObfuscatedString {
@@ -155,10 +153,8 @@ extension ObfuscatedString: ExpressionMacro {
                 (codeBlockItems, data) = obfuscateByXOR(codeBlockItems, data: data)
             case .base64:
                 (codeBlockItems, data) = obfuscateByBase64(codeBlockItems, data: data)
-#if canImport(CryptoKit)
             case .AES:
                 (codeBlockItems, data) = obfuscateByAES(codeBlockItems, data: data)
-#endif
             }
         }
 
@@ -289,7 +285,6 @@ extension ObfuscatedString {
         return (codeBlockItems, obfuscatedData)
     }
 
-#if canImport(CryptoKit)
     /// Obfuscates the given string using AES operation.
     ///
     /// A 128-bit random key is used
@@ -333,5 +328,4 @@ extension ObfuscatedString {
 
         return (codeBlockItems, encryptedData)
     }
-#endif
 }

--- a/Sources/ObfuscateSupport/Method.swift
+++ b/Sources/ObfuscateSupport/Method.swift
@@ -18,10 +18,8 @@ public enum ObfuscateMethod {
         case bitXOR
         /// Obfuscation using base64 encoding.
         case base64
-#if canImport(CryptoKit)
         /// Obfuscation using AES encryption.
         case AES
-#endif
     }
     
     /// Obfuscation using bit shifting.
@@ -30,10 +28,8 @@ public enum ObfuscateMethod {
     case bitXOR
     /// Obfuscation using base64 encoding.
     case base64
-#if canImport(CryptoKit)
     /// Obfuscation using AES encryption.
     case AES
-#endif
     
     /// Randomly selects one obfuscation method from all available methods.
     case randomAll

--- a/Tests/ObfuscateMacroTests/ObfuscateMacroTests.swift
+++ b/Tests/ObfuscateMacroTests/ObfuscateMacroTests.swift
@@ -34,12 +34,10 @@ final class ObfuscateMacroTests: XCTestCase {
             "hello, こんにちは, 👪",
             #ObfuscatedString("hello, こんにちは, 👪", method: .base64)
         )
-#if canImport(CryptoKit)
         XCTAssertEqual(
             "hello, こんにちは, 👪",
             #ObfuscatedString("hello, こんにちは, 👪", method: .AES)
         )
-#endif
         XCTAssertEqual(
             "hello, こんにちは, 👪",
             #ObfuscatedString("hello, こんにちは, 👪", repetitions: 5)
@@ -70,7 +68,6 @@ final class ObfuscateMacroTests: XCTestCase {
                 method: .base64
             )
         )
-#if canImport(CryptoKit)
         XCTAssertEqual(
             original,
             #ObfuscatedString(
@@ -78,7 +75,6 @@ final class ObfuscateMacroTests: XCTestCase {
                 method: .AES
             )
         )
-#endif
     }
 
     func testBitShift() {
@@ -159,7 +155,6 @@ final class ObfuscateMacroTests: XCTestCase {
         )
     }
 
-#if canImport(CryptoKit)
     func testAES() {
         assertMacroExpansion(
             """
@@ -190,7 +185,6 @@ final class ObfuscateMacroTests: XCTestCase {
             macros: macros
         )
     }
-#endif
 
     func testRandomAll() {
         let originalSource = """


### PR DESCRIPTION
This will allow cross-platform support for `ObfuscateMethod.AES` and also make it easier to add new methods in the future that use the `Crypto` package.