### PR TITLE
Use `swift-actions/setup-swift` on Linux tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Swift
-        uses: slashmo/install-swift@v0.4.0
+        uses: swift-actions/setup-swift@v2
         with:
-          version: swift-5.9-RELEASE
+          swift-version: "5.9.0"
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
On the Linux test action it seems like something is failing when trying to install 5.9 and so it ends up installing the latest release instead (currently 6.0.1).