### PR TITLE
Require `String` argument to be "static"

### DIFF
--- a/Sources/ObfuscateMacroPlugin/ObfuscateMacroDiagnostic.swift
+++ b/Sources/ObfuscateMacroPlugin/ObfuscateMacroDiagnostic.swift
@@ -11,6 +11,7 @@ import SwiftDiagnostics
 
 public enum ObfuscateMacroDiagnostic {
     case failedToParseArguments
+    case stringIsNotStatic
     case methodCandidateIsEmpty
 }
 
@@ -23,6 +24,8 @@ extension ObfuscateMacroDiagnostic: DiagnosticMessage {
         switch self {
         case .failedToParseArguments:
             return "Failed to parse arguments of this macro"
+        case .stringIsNotStatic:
+            return "The provided string must be static."
         case .methodCandidateIsEmpty:
             return "The element specified in `ObfuscateMethod.random` is empty."
         }


### PR DESCRIPTION
We probably don't want something like this to succeed:

```swift
let worldString = "world"
let hello = #ObfuscatedString("Hello, \(worldString)!")
print(hello) // prints "Hello, \(world)!"
```

With this change, you'll now get an error: "The provided string must be static."

In the future, we could probably do some magic to actually make string interpolation work. But in the meantime, let's at least make the expansion error out.