### PR TITLE
Use platform-specific newlines in multiline string test

### DIFF
--- a/Tests/ObfuscateMacroTests/ObfuscateMacroTests.swift
+++ b/Tests/ObfuscateMacroTests/ObfuscateMacroTests.swift
@@ -442,7 +442,7 @@ final class ObfuscateMacroTests: XCTestCase {
             Line 2
             hello, こんにちは, 👪
             3
-            """
+            """.withPlatformNewLine
         )
     }
 


### PR DESCRIPTION
- Updated multiline string in test to use `.withPlatformNewLine`

https://github.com/p-x9/ObfuscateMacro/actions/runs/18224742099/job/51894391504?pr=29